### PR TITLE
fun.op as alias to fun.operator

### DIFF
--- a/fun.lua
+++ b/fun.lua
@@ -950,7 +950,8 @@ local exports = {
     ----------------------------------------------------------------------------
     -- Operators
     ----------------------------------------------------------------------------
-    operator = operator
+    operator = operator,
+    op = operator -- an alias
 }
 
 -- a special syntax sugar to export all functions to the global table


### PR DESCRIPTION
Hi,

I am hereby suggesting `fun.op` as an alias to `fun.operator`.
Since "op" is a common short for "operator", I think it remains still explicit enough, and it makes less typing.

Regards,
Roland.
