### PR TITLE
Added support for non LuaJit and bitwise ops

### DIFF
--- a/fun.lua
+++ b/fun.lua
@@ -823,21 +823,32 @@ operator = {
     lor = function(a, b) return a or b end,
     lnot = function(a) return not a end,
     truth = function(a) return not not a end,
-
-    ----------------------------------------------------------------------------
-    -- Bit operators
-    ----------------------------------------------------------------------------
-    band = bit.band,
-    rol = bit.rol,
-    ror = bit.ror,
-    arshift = bit.arshift,
-    lshift = bit.lshift,
-    rshift = bit.rshift,
-    bswap = bit.bswap,
-    bor = bit.bor,
-    bnot = bit.bnot,
-    bxor = bit.bxor,
 }
+
+----------------------------------------------------------------------------
+  -- Bit operators
+----------------------------------------------------------------------------
+
+-- Enable bit ops iff a bitwise op library was found available.
+-- Defaults to LuaJit bit library if LuaJit was found.
+local hasBit, bit = jit or (pcall(require, 'bit'))
+
+if hasBit then
+
+  bit = bit or package.loaded['bit']
+
+  operator.band    = bit.band
+  operator.rol     = bit.rol
+  operator.ror     = bit.ror
+  operator.arshift = bit.arshift
+  operator.lshift  = bit.lshift
+  operator.rshift  = bit.rshift
+  operator.bswap   = bit.bswap
+  operator.bor     = bit.bor
+  operator.bnot    = bit.bnot
+  operator.bxor    = bit.bxor
+  
+end
 
 --------------------------------------------------------------------------------
 -- module definitions


### PR DESCRIPTION
Hi,

In its current state, this cannot be used without LuaJiT.
The current patch changes that behaviour. In case LuaJIT was found, everything goes as expected.
In case LuaJiT was not found, it will look for an external bitwise op library (through require), and will try to import some specific functions to `fun.operator`.
In case LuaJIT was not found, and also no external bitwise ops library was found, no bitwise op function will be imported (`fun.operator.band`, `fun.operator.bor`, `fun.operator.ror`, etc...)  will just be `nil`.

The motive for this was to make the library available to most of Lua users, using LuaJIT or not. Using LuaJIT, one will take advantage of it, but it still remains available to standard Lua users as well :)

Regards,
Roland.
