### PR TITLE
When exporting the functions to the global space it will shows a notice or a warning if the functions already exists in the global space.

### DIFF
--- a/fun.lua
+++ b/fun.lua
@@ -1041,7 +1041,7 @@ setmetatable(exports, {
 
                 if (override) then
                     _G[k] = v
-                    print('WARNING: ' .. msg .. ' Overriden.')
+                    print('WARNING: ' .. msg .. ' Overwritten.')
                 else
                     print('NOTICE: ' .. msg .. ' Skipped.')
                 end

--- a/fun.lua
+++ b/fun.lua
@@ -1033,8 +1033,22 @@ methods.op = operator
 
 -- a special syntax sugar to export all functions to the global table
 setmetatable(exports, {
-    __call = function(t)
-        for k, v in pairs(t) do _G[k] = v end
+    __call = function(t, override)
+        for k, v in pairs(t) do 
+            
+            if _G[k] ~= nil then
+                local msg = 'function ' .. k .. ' already exists in global scope.'
+
+                if (override) then
+                    _G[k] = v
+                    print('WARNING: ' .. msg .. ' Overriden.')
+                else
+                    print('NOTICE: ' .. msg .. ' Skipped.')
+                end
+            else
+                _G[k] = v
+            end
+        end
     end,
 })
 


### PR DESCRIPTION
This is useful if you use another libraries that also export functions to global space.