### PR TITLE
Fix chain() to work correctly with maps

### DIFF
--- a/fun.lua
+++ b/fun.lua
@@ -941,7 +941,7 @@ local chain_gen_r2 = function(param, state, state_x, ...)
     if state_x == nil then
         local i = state[1]
         i = i + 1
-        if i > #param / 3 then
+        if param[3 * i - 1] == nil then
             return nil
         end
         local state_x = param[3 * i]

--- a/tests/compositions.lua
+++ b/tests/compositions.lua
@@ -143,6 +143,22 @@ three
 3 c
 --test]]
 
+local tab = {}
+local keys = {}
+for _it, k, v in chain({ a = 11, b = 12, c = 13}, { d = 21, e = 22 }) do
+    tab[k] = v
+    table.insert(keys, k)
+end
+table.sort(keys)
+for _, key in ipairs(keys) do print(key, tab[key]) end
+--[[test
+a 11
+b 12
+c 13
+d 21
+e 22
+--test]]
+
 dump(chain(range(0), range(0), range(0)))
 --[[test
 error: invalid iterator


### PR DESCRIPTION
Problem: When the 2nd+ argument is a map, then `chain()` iterates only over the first iterator.

Reason: `chain_gen_r2()` returns the next iterator only if `2 > #param / 3`. This test does not work correctly when any of the chain's arguments is a map - in that case the `params` table is sparse. Why? The problem is in `gen_x, param_x, state_x = iter(elem)` – `state_x` is always nil when `elem` is a map.

This patch fixes this problem.