### PR TITLE
`from` wrapper, table iteration utilities, and fix `iter`'s handling of __pairs metamethods

### DIFF
--- a/doc/basic.rst
+++ b/doc/basic.rst
@@ -96,6 +96,50 @@ The section contains functions to create iterators from Lua objects.
    .. [#luajit_lua52compat] http://luajit.org/extensions.html
    .. [#lua52_ipairs] http://www.lua.org/manual/5.2/manual.html#pdf-ipairs
 
+.. function:: from(gen, param, state)
+
+   :returns: ``gen, param, state`` -- :ref:`iterator triplet <iterator_triplet>`
+
+   Wraps an existing :ref:`iterator triplet <iterator_triplet>` into a form
+   which is compatible with library functions. It is designed to directly adapt
+   existing iterator triplets (e.g., from ``ipairs`` or ``string.gmatch``).
+   
+   Unlike :func:`iter`, this wrapper preserves all values returned by the
+   generating function. For historical reasons, when using :func:`iter` with a
+   generator triplet, the first element returned by the generating function,
+   usually the state, is inaccessible. :func:`from` avoids this behavior, making
+   it suitable for iterators whose first returned values are needed.
+
+   Examples:
+
+   .. code-block:: lua
+
+    > for _it, i, v in from(ipairs({"a", "b", "c"})) do print(i, v) end
+    1 a
+    2 b
+    3 c
+
+    > for _it, a, b in from(string.gmatch('a1b2c3', '(%a)(%d)')) do print(a, b) end
+    a 1
+    b 2
+    c 3
+
+   Contrast with :func:`iter`'s behavior:
+
+   .. code-block:: lua
+
+    > -- ``i``` is inaccessible
+    > for _it, v in iter(ipairs({"a", "b", "c"})) do print(v) end
+    a
+    b
+    c
+
+    > -- ``a``` is inaccessible
+    > for _it, b in iter(string.gmatch('a1b2c3', '(%a)(%d)')) do print(b) end
+    1
+    2
+    3
+
 .. function:: each(fun, gen, param, state)
               iterator:each(fun)
 

--- a/doc/basic.rst
+++ b/doc/basic.rst
@@ -140,6 +140,54 @@ The section contains functions to create iterators from Lua objects.
     2
     3
 
+.. function:: ipairs_of(array)
+
+   :returns: ``gen, param, state`` -- :ref:`iterator triplet <iterator_triplet>`
+
+   Returns an iterator triplet equivalent to ``from(ipairs(array))``. This
+   function is aware of the ``__ipairs`` metamethod.
+
+   Example:
+
+   .. code-block:: lua
+
+    > for _it, i, v in ipairs_of({"a", "b", "c"}) do print(i, v) end
+    1 a
+    2 b
+    3 c
+
+.. function:: pairs_of(map)
+
+   :returns: ``gen, param, state`` -- :ref:`iterator triplet <iterator_triplet>`
+
+   Returns an iterator triplet equivalent to ``from(pairs(map))``. This function 
+   is aware of the ``__pairs`` metamethod.
+
+   Example:
+
+   .. code-block:: lua
+
+    > for _it, k, v in pairs_of({ a = 1, b = 2, c = 3 }) do print(k, v) end
+    b 2
+    a 1
+    c 3
+
+.. function:: items(tab)
+
+   :returns: ``gen, param, state`` -- :ref:`iterator triplet <iterator_triplet>`
+
+   Returns an iterator triplet that iterates over array elements of a table
+   using ``ipairs``. This function is aware of the ``__ipairs`` metamethod.
+
+   Example:
+
+   .. code-block:: lua
+
+    > for _it, a in items({ 1, 2, 3, a = 4, b = 5, c = 6 }) do print(a) end
+    1
+    2
+    3
+
 .. function:: each(fun, gen, param, state)
               iterator:each(fun)
 

--- a/fun.lua
+++ b/fun.lua
@@ -30,6 +30,10 @@ local call_if_not_empty = function(fun, state_x, ...)
     return state_x, fun(...)
 end
 
+local duplicate_state = function(state_x, ...)
+    return state_x, state_x, ...
+end
+
 local function deepcopy(orig) -- used by cycle()
     local orig_type = type(orig)
     local copy
@@ -56,6 +60,12 @@ local iterator_mt = {
     __index = methods;
 }
 
+local to_duplicate_state_gen = function(gen)
+	return function (param, state)
+		return duplicate_state(gen(param, state))
+	end
+end
+
 local wrap = function(gen, param, state)
     return setmetatable({
         gen = gen,
@@ -65,8 +75,18 @@ local wrap = function(gen, param, state)
 end
 exports.wrap = wrap
 
+local from = function(gen, param, state)
+    return setmetatable({
+        raw_gen = gen,
+        gen = to_duplicate_state_gen(gen),
+        param = param,
+        state = state
+    }, iterator_mt), param, state
+end
+exports.from = from
+
 local unwrap = function(self)
-    return self.gen, self.param, self.state
+    return self.raw_gen or self.gen, self.param, self.state
 end
 methods.unwrap = unwrap
 
@@ -90,11 +110,7 @@ end
 local ipairs_gen = ipairs({}) -- get the generating function from ipairs
 
 local pairs_gen = pairs({ a = 0 }) -- get the generating function from pairs
-local map_gen = function(tab, key)
-    local value
-    local key, value = pairs_gen(tab, key)
-    return key, key, value
-end
+local kkv_gen = to_duplicate_state_gen(pairs_gen)
 
 local rawiter = function(obj, param, state)
     assert(obj ~= nil, "invalid iterator")
@@ -106,7 +122,7 @@ local rawiter = function(obj, param, state)
             elseif mt.__ipairs ~= nil then
                 return mt.__ipairs(obj)
             elseif mt.__pairs ~= nil then
-                return mt.__pairs(obj)
+                return from(mt.__pairs(obj))
             end
         end
         if #obj > 0 then
@@ -114,7 +130,7 @@ local rawiter = function(obj, param, state)
             return ipairs(obj)
         else
             -- hash
-            return map_gen, obj, nil
+            return kkv_gen, obj, nil
         end
     elseif (type(obj) == "function") then
         return obj, param, state

--- a/fun.lua
+++ b/fun.lua
@@ -66,22 +66,22 @@ local to_duplicate_state_gen = function(gen)
 	end
 end
 
-local wrap = function(gen, param, state)
+local new_iterator = function(gen, param, state, raw_gen)
     return setmetatable({
         gen = gen,
         param = param,
-        state = state
+        state = state,
+        raw_gen = raw_gen,
     }, iterator_mt), param, state
+end
+
+local wrap = function(gen, param, state)
+    return new_iterator(gen, param, state)
 end
 exports.wrap = wrap
 
 local from = function(gen, param, state)
-    return setmetatable({
-        raw_gen = gen,
-        gen = to_duplicate_state_gen(gen),
-        param = param,
-        state = state
-    }, iterator_mt), param, state
+    return new_iterator(to_duplicate_state_gen(gen), param, state, gen)
 end
 exports.from = from
 
@@ -108,7 +108,7 @@ local string_gen = function(param, state)
 end
 
 local ipairs_gen = ipairs({}) -- get the generating function from ipairs
-
+local iiv_gen = to_duplicate_state_gen(ipairs_gen)
 local pairs_gen = pairs({ a = 0 }) -- get the generating function from pairs
 local kkv_gen = to_duplicate_state_gen(pairs_gen)
 
@@ -148,6 +148,36 @@ local iter = function(obj, param, state)
     return wrap(rawiter(obj, param, state))
 end
 exports.iter = iter
+
+local items = function(tab)
+    local mt = getmetatable(tab)
+    if mt and mt.__ipairs then
+        return wrap(mt.__ipairs(tab))
+    end
+    assert(type(tab) == "table", "invalid argument to items")
+    return wrap(ipairs(tab))
+end
+exports.items = items
+
+local ipairs_of = function(tab)
+    local mt = getmetatable(tab)
+    if mt and mt.__ipairs then
+        return from(mt.__ipairs(tab))
+    end
+    assert(type(tab) == "table", "invalid argument to ipairs_of")
+    return new_iterator(iiv_gen, tab, 0, ipairs_gen)
+end
+exports.ipairs_of = ipairs_of
+
+local pairs_of = function(tab)
+    local mt = getmetatable(tab)
+    if mt and mt.__pairs then
+        return from(mt.__pairs(tab))
+    end
+    assert(type(tab) == "table", "invalid argument to pairs_of")
+    return new_iterator(kkv_gen, tab, nil, pairs_gen)
+end
+exports.pairs_of = pairs_of
 
 local method0 = function(fun)
     return function(self)

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -347,6 +347,136 @@ true true true
 --test]]
 
 --------------------------------------------------------------------------------
+-- items, ipairs_of, pairs_of
+--------------------------------------------------------------------------------
+
+--
+-- items
+--
+
+for _it, a in items({1, 2, 3}) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in items(tab_with_ipairs) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in items({ 1, 2, 3, a = 4, b = 5, c = 6 }) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in items(tab_with_ipairs_and_pairs) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+--
+-- ipairs_of
+--
+
+for _it, i, v in ipairs_of({1, 2, 3}) do print(i, v) end
+--[[test
+1 1
+2 2
+3 3
+--test]]
+
+for _it, i, v in ipairs_of(tab_with_ipairs) do print(i, v) end
+--[[test
+1 1
+2 2
+3 3
+--test]]
+
+for _it, i, v in ipairs_of({ 1, 2, 3, a = 4, b = 5, c = 6 }) do print(i, v) end
+--[[test
+1 1
+2 2
+3 3
+--test]]
+
+for _it, i, v in ipairs_of(tab_with_ipairs_and_pairs) do print(i, v) end
+--[[test
+1 1
+2 2
+3 3
+--test]]
+
+local t = { 1 }
+local gen1, param1, state1 = ipairs(t)
+local gen2, param2, state2 = ipairs_of(t):unwrap()
+print(gen1 == gen2, param1 == param2, state1 == state2)
+--[[test
+true true true
+--test]]
+
+--
+-- pairs_of
+--
+
+local t = {}
+local keys = {}
+for _it, k, v in pairs_of({ a = 1, b = 2, c = 3 }) do
+    t[k] = v
+    keys[#keys + 1] = k
+end
+table.sort(keys)
+for _, k in ipairs(keys) do print(k, t[k]) end
+--[[test
+a 1
+b 2
+c 3
+--test]]
+
+local t = {}
+local keys = {}
+for _it, k, v in pairs_of(tab_with_pairs) do
+    t[k] = v
+    keys[#keys + 1] = k
+end
+table.sort(keys)
+for _, k in ipairs(keys) do print(k, t[k]) end
+--[[test
+a 1
+b 2
+c 3
+--test]]
+
+local t = {}
+local keys = {}
+for _it, k, v in pairs_of(tab_with_ipairs_and_pairs) do
+    t[k] = v
+    keys[#keys + 1] = k
+end
+table.sort(keys)
+for _, k in ipairs(keys) do print(k, t[k]) end
+--[[test
+a 4
+b 5
+c 6
+--test]]
+
+local t = { a = 1 }
+local gen1, param1, state1 = pairs(t)
+local gen2, param2, state2 = pairs_of(t):unwrap()
+print(gen1 == gen2, param1 == param2, state1 == state2)
+--[[test
+true true true
+--test]]
+
+--------------------------------------------------------------------------------
 -- each
 --------------------------------------------------------------------------------
 

--- a/tests/basic.lua
+++ b/tests/basic.lua
@@ -34,6 +34,109 @@ for _it, a in wrap(wrap(ipairs({1, 2, 3}))) do print(a) end
 3
 --test]]
 
+tab_with_ipairs = setmetatable({}, {
+    __ipairs = function() return ipairs({1, 2, 3}) end,
+})
+for _it, a in iter(tab_with_ipairs) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in iter(iter(iter(tab_with_ipairs))) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in wrap(wrap(iter(tab_with_ipairs))) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in
+    wrap(wrap(getmetatable(tab_with_ipairs).__ipairs(tab_with_ipairs)))
+do
+    print(a)
+end
+--[[test
+1
+2
+3
+--test]]
+
+-- Check that ``iter`` treats tables with both array part and map part as arrays
+for _it, a in iter({ 1, 2, 3, a = 4, b = 5, c = 6 }) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in iter(iter(iter({ 1, 2, 3, a = 4, b = 5, c = 6 }))) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in wrap(wrap(iter({ 1, 2, 3, a = 4, b = 5, c = 6 }))) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in wrap(wrap(ipairs({ 1, 2, 3, a = 4, b = 5, c = 6 }))) do
+    print(a)
+end
+--[[test
+1
+2
+3
+--test]]
+
+-- Check that ``iter`` treats objects with both ``__ipairs`` and ``__pairs``
+-- metamethods as arrays
+tab_with_ipairs_and_pairs = setmetatable({}, {
+    __ipairs = function() return ipairs({1, 2, 3}) end,
+    __pairs = function() return pairs({ a = 4, b = 5, c = 6 }) end,
+})
+
+for _it, a in iter(tab_with_ipairs_and_pairs) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in iter(iter(iter(tab_with_ipairs_and_pairs))) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in wrap(wrap(iter(tab_with_ipairs_and_pairs))) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
+for _it, a in wrap(wrap(
+    getmetatable(tab_with_ipairs_and_pairs).__ipairs(tab_with_ipairs_and_pairs)
+)) do print(a) end
+--[[test
+1
+2
+3
+--test]]
+
 for _it, a in iter({}) do print(a) end
 --[[test
 --test]]
@@ -91,6 +194,30 @@ b
 c
 --test]]
 
+tab_with_pairs = setmetatable({}, {
+    __pairs = function() return pairs({ a = 1, b = 2, c = 3 }) end,
+})
+
+local t = {}
+for _it, k, v in iter(tab_with_pairs) do t[#t + 1] = k end
+table.sort(t)
+for _it, v in iter(t) do print(v) end
+--[[test
+a
+b
+c
+--test]]
+
+local t = {}
+for _it, k, v in iter(iter(iter(tab_with_pairs))) do t[#t + 1] = k end
+table.sort(t)
+for _it, v in iter(t) do print(v) end
+--[[test
+a
+b
+c
+--test]]
+
 for _it, k, v in iter({}) do print(k, v) end
 --[[test
 --test]]
@@ -140,7 +267,7 @@ local function mypairs_gen(max, state)
         return state + 1, state + 1
 end
 
-local function mypairs(max)
+function mypairs(max)
     return mypairs_gen, max, 0
 end
 
@@ -170,6 +297,53 @@ error: object 1 of type "number" is not iterable
 for _it, a in iter(1, 2, 3, 4, 5, 6, 7) do print(a) end
 --[[test
 error: object 1 of type "number" is not iterable
+--test]]
+
+--------------------------------------------------------------------------------
+-- from
+--------------------------------------------------------------------------------
+
+for _it, i, v in from(ipairs({1, 2, 3})) do print(i, v) end
+--[[test
+1 1
+2 2
+3 3
+--test]]
+
+local t = {}
+local keys = {}
+for _it, k, v in from(pairs({ a = 1, b = 2, c = 3 })) do
+    t[k] = v
+    keys[#keys + 1] = k
+end
+table.sort(keys)
+for _, k in ipairs(keys) do print(k, t[k]) end
+--[[test
+a 1
+b 2
+c 3
+--test]]
+
+for _it, a, b in from(string.gmatch('a1b2c3', '(%a)(%d)')) do print(a, b) end
+--[[test
+a 1
+b 2
+c 3
+--test]]
+
+for _it, a, b in from(mypairs(3)) do print(a, b) end
+--[[test
+1 1
+2 2
+3 3
+--test]]
+
+-- Check that ``from`` holds the original generator
+gen1, param1, state1 = pairs({ a = 1, b = 2, c = 3 })
+gen2, param2, state2 = from(gen1, param1, state1):unwrap()
+print(gen1 == gen2, param1 == param2, state1 == state2)
+--[[test
+true true true
 --test]]
 
 --------------------------------------------------------------------------------


### PR DESCRIPTION
## 1. A wrapper function that does not hide state

Suppose we want to iterate over captures from `string.gmatch`:

```lua
> iter(string.gmatch('a1b2c3', '(%a)(%d)')):each(print)
1
2
3
```

We lose every first capture. Indeed, the inaccessibility of the first returned value happens to all iterator functions.

To solve this problem, this PR introduces `from`. It does not hide the first returned value.

```lua
> from(string.gmatch('a1b2c3', '(%a)(%d)')):each(print)
a       1
b       2
c       3
```

## 2. Three util functions to iterate a table in a certain way

Some tables can be an array and a map at the same time and `iter` always considers them arrays. These three new functions will solve the problem: `ipairs_of`, `pairs_of` and `items`. (fixes #30)

```lua
> ipairs_of({ 1, 2, a = 3, b = 4 }):each(print)
1       1
2       2

> pairs_of({ 1, 2, a = 3, b = 4 }):each(print)
1       1
2       2
a       3
b       4

> items({ 1, 2, a = 3, b = 4 }):each(print)  -- the same as iter(...) for this case
1
2
```

## 3. Fix the bug that `iter` does not handle objects with `__pairs` metamethods properly

Before:

```lua
> iter({ a = 1, b = 2 }):each(print)
a       1
b       2

> t = setmetatable({}, { __pairs = function () return pairs({ a = 1, b = 2 }) end })
> iter(t):each(print)
1
2
-- missing keys
```

After:
```lua
> t = setmetatable({}, { __pairs = function () return pairs({ a = 1, b = 2 }) end })
> iter(t):each(print)
a       1
b       2
```

This PR also adds more tests for `iter`.

## Difference from #52

Both this PR and #52 solve problem 1 & 2 above.

For the first problem. #52 introduced `:with_key()` method (e.g., `iter(string.gmatch('a1b2c3', '(%a)(%d)')):with_key():each(print))`). IMO my solution is more elegant.

For the seconde problem, #52 introduced `map_pairs` and `pairs`. However, their names are confusing ([see this](https://github.com/luafun/luafun/pull/52/files#r335197109)). Moreover, `fun.pairs` conflicts with Lua's `pairs` when imported to the global table.

## Others

This PR fixes #51, too.
