### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,12 +57,13 @@ Readable? Efficient? Can your Python/Ruby/V8 do better?
 Status
 ------
 
-**Lua Fun** is in an early alpha stage. The library fully
+**Lua Fun** is in an early stage. 
+The library is fully
 [documented][Documentation] and covered with unit tests.
 
 [![Build Status](https://travis-ci.org/luafun/luafun.png)][Travis]
 
-LuaJIT 2.1 alpha is recommended. The library designed in mind of fact that
+LuaJIT 2.1 beta is recommended. The library designed in mind of fact that
 [LuaJIT traces tail-, up- and down-recursion][LuaJIT-Recursion] and has a lot of
 [byte code optimizations][LuaJIT-Optimizations]. Lua 5.1-5.3 are also
 supported.


### PR DESCRIPTION
LuaFun is arguably not in alpha anymore. And for sure is LuaJIT beta, and not alpha recommended. This also corrects a typo.