### PR TITLE
Add link to luarocks on getting_started.rst

### DIFF
--- a/doc/getting_started.rst
+++ b/doc/getting_started.rst
@@ -96,7 +96,7 @@ Installing the Library
 Using LuaRocks
 ``````````````
 
-Use the rockspec_ file.
+Use the rockspec_ file for https://luarocks.org/modules/rtsisyk/fun.
 
 .. _rockspec: https://raw.github.com/luafun/luafun/master/fun-scm-1.rockspec
 


### PR DESCRIPTION
Add a simple and explicit link to the right library on luarocks.
The search shows multiple results https://luarocks.org/search?q=fun.lua so adding a link prevent picking the wrong one.