### PR TITLE
change implementation of min_by and max_by to match documentation

### DIFF
--- a/doc/reducing.rst
+++ b/doc/reducing.rst
@@ -271,9 +271,9 @@ Special folds
 
    .. code-block:: lua
 
-    > function min_cmp(a, b) if -a < -b then return a else return b end end
-    > print(min_by(min_cmp, range(1, 10, 1)))
-    9
+    > function opp_cmp(a, b) return -a < -b end
+    > print(min_by(opp_cmp, range(1, 10, 1)))
+    10
 
 .. function:: minimum_by(cmp, gen, param, state)
 
@@ -307,14 +307,14 @@ Special folds
 .. function:: max_by(cmp, gen, param, state)
               iterator:max_by(cmp)
 
-   Return a maximum value from the iterator using the **cmp** as a `>`
+   Return a maximum value from the iterator using the **cmp** as a `<`
    operator. The iterator must be non-null, otherwise an error is raised.
 
    Examples:
 
    .. code-block:: lua
 
-    > function max_cmp(a, b) if -a > -b then return a else return b end end
+    > function max_cmp(a, b) return -a < -b end
     > print(max_by(max_cmp, range(1, 10, 1)))
     1
 

--- a/fun.lua
+++ b/fun.lua
@@ -740,7 +740,7 @@ local min_by = function(cmp, gen_x, param_x, state_x)
     end
 
     for _, r in gen_x, param_x, state_x do
-        m = cmp(m, r)
+        m = cmp(m, r) and m or r
     end
     return m
 end
@@ -780,7 +780,7 @@ local max_by = function(cmp, gen_x, param_x, state_x)
     end
 
     for _, r in gen_x, param_x, state_x do
-        m = cmp(m, r)
+        m = cmp(m, r) and r or m
     end
     return m
 end

--- a/tests/reducing.lua
+++ b/tests/reducing.lua
@@ -297,16 +297,16 @@ true
 -- min_by
 --------------------------------------------------------------------------------
 
-function min_cmp(a, b) if -a < -b then return a else return b end end
+function opp_cmp(a, b) return -a < -b end
 --[[test
 --test]]
 
-print(min_by(min_cmp, range(1, 10, 1)))
+print(min_by(opp_cmp, range(1, 10, 1)))
 --[[test
 10
 --test]]
 
-print(min_by(min_cmp, {}))
+print(min_by(opp_cmp, {}))
 --[[test
 error: min: iterator is empty
 --test]]
@@ -344,16 +344,16 @@ true
 -- max_by
 --------------------------------------------------------------------------------
 
-function max_cmp(a, b) if -a > -b then return a else return b end end
+function opp_cmp(a, b) return -a < -b end
 --[[test
 --test]]
 
-print(max_by(max_cmp, range(1, 10, 1)))
+print(max_by(opp_cmp, range(1, 10, 1)))
 --[[test
 1
 --test]]
 
-print(max_by(max_cmp, {}))
+print(max_by(opp_cmp, {}))
 --[[test
 error: max: iterator is empty
 --test]]


### PR DESCRIPTION
Change the implementation of the min_by and max_by functions to match the documented behaviour as described in https://github.com/luafun/luafun/issues/13 and fix the bug mentioned in https://github.com/luafun/luafun/issues/95 where the two functions given the same iterator and the same comparison function would return the same value, instead of the actual min and max as desired. This does not provide the projection function mentioned in https://github.com/luafun/luafun/issues/13, i think this should be a third function, probably something like `min_by_key` as exemplified for example by the rust itertools package.